### PR TITLE
fix: update panel when resize window

### DIFF
--- a/src/ElementInfo.vue
+++ b/src/ElementInfo.vue
@@ -303,7 +303,7 @@ useEventListener('scroll', updateElementInfo, { capture: true })
     <div class="flex-1 overflow-y-auto relative no-scrollbar">
       <Transition :name="`slide-${slideDirection}`" mode="out-in">
         <KeepAlive>
-          <component :is="activeTab.component" :key="activeTab.id" class="p-4" />
+          <component :is="activeTab.component" :key="activeTab.id" />
         </KeepAlive>
       </Transition>
     </div>


### PR DESCRIPTION
when I selected a dom, I open the Browser Devtools, the panel will be blocked by devtools